### PR TITLE
Add a testing framework

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,11 @@ project('something-sonic', 'c',
         default_options: 'default_library=static')
 
 sdl2_dep = dependency('sdl2')
+cmocka_dep = dependency('cmocka')
 
 executable('game', 'game.c',
            win_subsystem: 'windows',
            dependencies: sdl2_dep)
+
+e = executable('prog', 'test/testprog.c', dependencies: cmocka_dep)
+test('testing tests', e)

--- a/subprojects/cmocka.wrap
+++ b/subprojects/cmocka.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = cmocka-1.1.5
+source_url = https://cmocka.org/files/1.1/cmocka-1.1.5.tar.xz
+source_filename = cmocka-1.1.5.tar.xz
+source_hash = f0ccd8242d55e2fd74b16ba518359151f6f8383ff8aef4976e48393f77bba8b6
+patch_url = https://wrapdb.mesonbuild.com/v2/cmocka_1.1.5-3/get_patch
+patch_filename = cmocka-1.1.5-3-wrap.zip
+patch_hash = 81ce48613680d3c3a0b396ac570c852b290adcd18202fb16aaf703a9493f4348
+

--- a/test/testprog.c
+++ b/test/testprog.c
@@ -1,0 +1,18 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+/* A test case that does nothing and succeeds. */
+static void null_test_success(void **state)
+{
+    (void)state; /* unused */
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(null_test_success),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
We're going to need one of these, so let's add it in now. The testing framework chosen is [cmocka](https://cmocka.org/) and the relevant meson config has also been added.